### PR TITLE
Use Unix socket

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -15,9 +15,10 @@ threads min_threads_count, max_threads_count
 #
 worker_timeout 3600 if ENV.fetch('RAILS_ENV', 'development') == 'development'
 
-# Specifies the `port` that Puma will listen on to receive requests; default is 3000.
-#
-port ENV.fetch('PORT', 3000)
+# Specifies the Unix socket Puma will listen on
+bind ENV.fetch('SOCKET', 'unix:///run/paste/puma')
+# Alternatively, specifies the `port` that Puma will listen on to receive requests; default is 3000.
+#port ENV.fetch('PORT', 3000)
 
 # Specifies the `environment` that Puma will run in.
 #


### PR DESCRIPTION
This sets the default configuration to listen on a Unix socket. Since the backend on our reference instance is proxied by a local web server, there is no need to for it to bind on a TCP listener.

We are using `bind 'unix:///run/paste/puma'` on our reference instance (paste.opensuse.org) since some months already, this patch slightly adjusts the configuration to allow for the path to be overwritten using an environment variable.