### PR TITLE
Remove Ruby version lock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,6 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '3.1.5'
-
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem 'rails', '~> 7.0.8'
 


### PR DESCRIPTION
Allow any Ruby version to avoid breakage upon updates in d:l:ruby.