### PR TITLE
Remove docker-compose version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "2.1"
 services:
   db:
     image: postgres:latest


### PR DESCRIPTION
Resolves:

```
WARN[0000] docker-compose.yml: `version` is obsolete
```