### PR TITLE
Serve text files inline

### DIFF
--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -1,0 +1,4 @@
+Rails.application.config.active_storage.content_types_allowed_inline +=
+  %w(
+    text/plain
+  )


### PR DESCRIPTION
Text-only pastes are preferably viewed in the browser instead of downloaded when using their "raw" links.
To have browsers render such raw files natively instead of saving them (which, depending on the browser and user defined browser preferences, either comes in the form of a download to a pre-defined directory or of a "Save as" dialogue), have the Content-Disposition header option get set to "inline" instead of "attachment" for text/plain content.