### PR TITLE
Only clean up pastes which exist

### DIFF
--- a/app/jobs/pastes_cleanup_job.rb
+++ b/app/jobs/pastes_cleanup_job.rb
@@ -4,7 +4,7 @@
 class PastesCleanupJob < ApplicationJob
   queue_as :default
 
-  def perform(paste)
-    paste.destroy
+  def perform(paste_id)
+    Paste.find_by(id: paste_id)&.destroy
   end
 end

--- a/app/models/paste.rb
+++ b/app/models/paste.rb
@@ -83,6 +83,6 @@ class Paste < ApplicationRecord
   end
 
   def enqueue_removal
-    PastesCleanupJob.set(wait_until: remove_at).perform_later(self)
+    PastesCleanupJob.set(wait_until: remove_at).perform_later(self&.id)
   end
 end


### PR DESCRIPTION
If pastes would be deleted administratively before the scheduled expiry cleanup took place, the cleanup job would, once the schedule hit, return "Error performing PastesCleanupJob" along with a long traceback about the failure.
Handle the situation gracefully and avoid the failure by validating whether the paste exists before attempting to delete it.
To achieve this, the paste ID instead of the paste object must be passed to the job, as otherwise the object in the queue might no longer be pointing to any valid paste, not allowing for validation of it inside the function.

https://progress.opensuse.org/issues/166121