### PR TITLE
Add human_url to JSON

### DIFF
--- a/app/views/pastes/_paste.json.jbuilder
+++ b/app/views/pastes/_paste.json.jbuilder
@@ -2,4 +2,5 @@
 
 json.extract! paste, :id, :author, :user_id, :title, :private, :remove_at, :content, :created_at, :updated_at
 json.url paste_url(paste, format: :json)
+json.human_url paste_url(paste)
 json.content url_for(paste.content)


### PR DESCRIPTION
For easier parsing in applications which use the JSON result to further provide information to users, add a "human_url" field which contains the paste URL without the .json suffix.