### PR TITLE
Fix locale error

### DIFF
--- a/app/models/paste.rb
+++ b/app/models/paste.rb
@@ -25,8 +25,8 @@ class Paste < ApplicationRecord
   attribute :remove_at, default: -> { Time.zone.now + 7.days.seconds }
 
   before_save :train_classifier
-  before_save :delete_spam
   before_save :check_terms
+  after_save :delete_spam
   before_create :create_permalink
   after_save :enqueue_removal
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -67,6 +67,7 @@ en:
   paste_destroyed: Paste was successfully destroyed.
   paste_not_destroyed: No permissions to destroy the paste.
   paste_not_found: Paste not found
+  paste_update: Paste was successfully updated.
   pastes_list: Listing pastes
   term_created: Term was successfully created.
   term_failed: Term failed to save.


### PR DESCRIPTION
Setting flags as a moderator was throwing the error:

`Translation missing: en.paste_update `

The spam flag was also not being set, due to delete_spam being called before_save, moved to after_save, local testing shows it's behaving properly now.