### PR TITLE
Fix 500 error when doing multi-tagging

### DIFF
--- a/app/controllers/pastes_controller.rb
+++ b/app/controllers/pastes_controller.rb
@@ -61,10 +61,9 @@ class PastesController < ApplicationController
   def spam
     authorize Paste.new
 
-    pastes = Paste.where(id: pastes_params[:ids])
-    results = pastes.map { |paste| paste.update(marked_kind: pastes_params[:marked_kinds], marked_by: current_user) }
-
-    if results.all?
+    if Paste.where(id: pastes_params[:ids]).map do |paste|
+      paste.update(marked_kind: pastes_params[:marked_kinds], marked_by: current_user)
+    end.all?
       redirect_to pastes_url, notice: t(:paste_update)
     else
       render :index, status: :unprocessable_content

--- a/app/controllers/pastes_controller.rb
+++ b/app/controllers/pastes_controller.rb
@@ -61,7 +61,10 @@ class PastesController < ApplicationController
   def spam
     authorize Paste.new
 
-    if Paste.where(id: pastes_params[:ids]).update(marked_kind: pastes_params[:marked_kinds], marked_by: current_user)
+    pastes = Paste.where(id: pastes_params[:ids])
+    results = pastes.map { |paste| paste.update(marked_kind: pastes_params[:marked_kinds], marked_by: current_user) }
+
+    if results.all?
       redirect_to pastes_url, notice: t(:paste_update)
     else
       render :index, status: :unprocessable_content

--- a/app/models/paste.rb
+++ b/app/models/paste.rb
@@ -56,7 +56,8 @@ class Paste < ApplicationRecord
     return '' unless content&.attachment
 
     content.attachment.open(&:read).force_encoding('utf-8')
-  rescue ActiveStorage::FileNotFoundError
+  rescue StandardError => e
+    Rails.logger.error("Paste##{id} failed to read attachment content: #{e.class}: #{e.message}")
     ''
   end
 
@@ -101,7 +102,7 @@ class Paste < ApplicationRecord
   end
 
   def train_classifier
-    return unless saved_change_to_marked_kind? || saved_change_to_marked_by_id?
+    return unless will_save_change_to_marked_kind? || will_save_change_to_marked_by_id?
     return if marked_kind == 'unclassified'
     return if marked_by.nil?
 


### PR DESCRIPTION
Change callback order, `before_create` before `after_save`

`Paste#code` - Broaden `rescue` to catch any attachment-read failure, logging it and returning '' rather than crashing the whole bulk-moderation request

`Paste#train_classifier` - Fixed `saved_change_to_*? -> will_save_change_to_*?`,
the former is always false inside `before_save`.   The classifier wasn't actually
training

`PastesController#spam` - Check per-record update results, rather than relying on `Relation#update` always-truthy return.  Partial falures now actually surface as `unprocessable_entity` instead of a false "success" redirect