### PR TITLE
Reset queue adapter settings in tests

### DIFF
--- a/spec/jobs/pastes_cleanup_job_spec.rb
+++ b/spec/jobs/pastes_cleanup_job_spec.rb
@@ -14,6 +14,11 @@ RSpec.describe PastesCleanupJob do
       freeze_time
     end
 
+    after do
+      ActiveJob::Base.queue_adapter.perform_enqueued_jobs = false
+      ActiveJob::Base.queue_adapter.perform_enqueued_at_jobs = false
+    end
+
     it 'enqueues the paste removal' do
       expect { paste }.to have_enqueued_job(described_class).on_queue('default')
     end


### PR DESCRIPTION
Without this, the tests failed sporadically, apparently due to pastes vanishing where they shouldn't.