### PR TITLE
Remove old redirect

### DIFF
--- a/app/controllers/oldapi_controller.rb
+++ b/app/controllers/oldapi_controller.rb
@@ -19,7 +19,8 @@ class OldapiController < ApplicationController
     if (@paste = Paste.find_by(permalink: params[:permalink]))
       redirect_to paste_url(@paste)
     else
-      redirect_to "https://susepaste.org/#{params[:permalink]}", allow_other_host: true
+      # TODO: maybe this would better be a 404
+      redirect_to pastes_url, alert: t(:paste_not_found)
     end
   end
 

--- a/spec/requests/oldapi_spec.rb
+++ b/spec/requests/oldapi_spec.rb
@@ -94,10 +94,10 @@ RSpec.describe 'Oldapis' do
 
   describe 'GET /:permalink' do
     context 'with non existing paste' do
-      it 'redirects to susepaste.org' do
+      it 'redirects to not found' do
         get "/#{SecureRandom.hex(6)}"
 
-        expect(response.redirect_url).to start_with('https://susepaste.org/')
+        expect(response).to redirect_to('http://www.example.com/pastes')
       end
     end
   end


### PR DESCRIPTION
susepaste.org is now a dubious domain.