### PR TITLE
Implement term apply upon save

### DIFF
--- a/app/controllers/terms_controller.rb
+++ b/app/controllers/terms_controller.rb
@@ -15,11 +15,24 @@ class TermsController < ApplicationController
     @term = authorize Term.new
   end
 
+  def enforce_term(term)
+    count = 0
+    Paste.where.not(marked_kind: 'spam').find_each do |paste|
+      count += 1 if paste.enforce_term!(term, current_user.id)
+    end
+
+    count
+  end
+
   def create
     @term = authorize Term.new(term_params)
 
     if @term.save
-      redirect_to terms_url, notice: t(:term_create)
+      if params[:save_and_apply].present?
+        redirect_to terms_url, notice: t(:term_created_applied, count: enforce_term(@term))
+      else
+        redirect_to terms_url, notice: t(:term_created)
+      end
     else
       render :new, status: :unprocessable_content
     end

--- a/app/models/paste.rb
+++ b/app/models/paste.rb
@@ -92,6 +92,13 @@ class Paste < ApplicationRecord
     errors.add(:remove_after, t(:too_long, time: largest_period.inspect)) if remove_after >= largest_period.seconds
   end
 
+  def enforce_term!(term, user_id)
+    return unless match_term?(term)
+
+    self.marked_by_id = user_id
+    save
+  end
+
   private
 
   def create_permalink
@@ -115,19 +122,23 @@ class Paste < ApplicationRecord
     destroy! if marked_by.present? && marked_kind == 'spam'
   end
 
+  def match_term?(term)
+    content = send(term.subject)
+
+    return false unless term.matches_regex?(content) || term.matches_substring?(content)
+
+    if term.action == 'mark_spam'
+      self.marked_kind = 'spam'
+    elsif term.action == 'remove'
+      self.remove_at = 5.seconds.from_now
+    end
+
+    true
+  end
+
   def check_terms
     Term.find_each do |term|
-      content = send(term.subject)
-
-      next unless term.matches_regex?(content) || term.matches_substring?(content)
-
-      if term.action == 'mark_spam'
-        self.marked_kind = 'spam'
-      elsif term.action == 'remove'
-        self.remove_at = 5.seconds.from_now
-      end
-
-      break
+      break if match_term?(term)
     end
   end
 

--- a/app/views/terms/new.html.haml
+++ b/app/views/terms/new.html.haml
@@ -19,3 +19,5 @@
                {}, { class: 'form-select' }
     = f.label :action, class: 'form-label'
   = f.submit t(:save), class: 'btn btn-primary'
+  = f.submit t(:save_and_apply),
+             name: 'save_and_apply', class: 'btn btn-primary'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,7 +72,11 @@ en:
   regular_expression: Regular expression
   term_created: Term was successfully created.
   term_failed: Term failed to save.
-  term_create: Term was successfully created.
+  term_created: Term was successfully created.
+  term_created_applied:
+    zero: Term was successfully created - no existing pastes matched.
+    one: Term was successfully created - enforced on 1 existing paste.
+    other: Term was successfully created - enforced on %{count} existing pastes.
   term_destroyed: Term was successfully destroyed.
   term_not_destroyed: No permissions to destroy the term.
   term_not_found: Term not found
@@ -105,6 +109,7 @@ en:
   no_attachment: No attachment
   options: Options
   save: Save
+  save_and_apply: Save and apply
   download: Download
   document_notice: You can only see the full document, if you download it
   expand: Expand

--- a/spec/features/terms_spec.rb
+++ b/spec/features/terms_spec.rb
@@ -84,6 +84,79 @@ RSpec.describe 'Terms' do
     end
   end
 
+  context 'when a moderator user tries to create and apply a spam term' do
+    let!(:dummy_paste) do
+      Paste.create!(
+        title: 'this contains a bad_word',
+        author: 'Anonymous',
+        code: 'some code content'
+      )
+    end
+
+    before do
+      OmniAuth.config.test_mode = true
+      OmniAuth.config.add_mock(:suse, { uid: '12345', info: { email: 'mod@opensuse.org', nickname: 'mod' } })
+      visit '/'
+      click_link_or_button 'Log in'
+
+      User.last.update(role: 'mod')
+
+      visit '/terms'
+      click_link 'Create', href: '/terms/new'
+      select 'Title', from: 'term_subject'
+      fill_in 'term_content', with: 'bad_word'
+      select 'Mark spam', from: 'term_action'
+      click_link_or_button 'Save and apply'
+    end
+
+    it 'creates the term', :aggregate_failures do
+      expect(page).to have_text('Term was successfully created - enforced on 1 existing paste.')
+      expect(page).to have_text('title with content: bad_word')
+    end
+
+    it 'enforces the term', :aggregate_failures do
+      # not checking mark as delete happens quickly after marking as spam
+      expect(Paste.exists?(dummy_paste.id)).to be false
+    end
+  end
+
+  context 'when a moderator user tries to create and apply a remove term' do
+    let!(:dummy_paste) do
+      Paste.create!(
+        title: 'this contains a bad_word',
+        author: 'Anonymous',
+        code: 'some code content'
+      )
+    end
+
+    before do
+      OmniAuth.config.test_mode = true
+      OmniAuth.config.add_mock(:suse, { uid: '12345', info: { email: 'mod@opensuse.org', nickname: 'mod' } })
+      visit '/'
+      click_link_or_button 'Log in'
+
+      User.last.update(role: 'mod')
+
+      visit '/terms'
+      click_link 'Create', href: '/terms/new'
+      select 'Title', from: 'term_subject'
+      fill_in 'term_content', with: 'bad_word'
+      select 'Remove', from: 'term_action'
+      click_link_or_button 'Save and apply'
+    end
+
+    it 'creates the term', :aggregate_failures do
+      expect(page).to have_text('Term was successfully created - enforced on 1 existing paste.')
+      expect(page).to have_text('title with content: bad_word')
+    end
+
+    it 'enforces the term', :aggregate_failures do
+      dummy_paste.reload
+      expect(dummy_paste.marked_by_id).to eq(User.last.id)
+      expect(dummy_paste.remove_at).to be_within(1.second).of(5.seconds.from_now)
+    end
+  end
+
   context 'when a moderator user tries to remove a term' do
     before do
       OmniAuth.config.test_mode = true


### PR DESCRIPTION
Avoid the need for manually cleaning up existing pastes after adding a
new term by offering a button which does it for you.

~// pending rebase after https://github.com/openSUSE/paste-o-o/pull/263~