### PR TITLE
Set charset in content type upon saving blobs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,3 +25,6 @@ AllCops:
 Layout/SpaceInsideParens:
   Exclude:
     - "**/*.haml"
+
+Metrics/ClassLength:
+  Max: 200

--- a/app/models/paste.rb
+++ b/app/models/paste.rb
@@ -26,6 +26,7 @@ class Paste < ApplicationRecord
 
   before_save :train_classifier
   before_save :check_terms
+  before_save :set_content_type
   before_create :create_permalink
   after_save :delete_spam
   after_save :enqueue_removal
@@ -127,5 +128,16 @@ class Paste < ApplicationRecord
 
       break
     end
+  end
+
+  def set_content_type
+    blob = content.blob
+
+    type = Rack::MediaType.type(blob.content_type)
+    params = Rack::MediaType.params(blob.content_type)
+
+    return unless type == 'text/plain' && !params.key?('charset')
+
+    blob.update(content_type: "#{type}; charset=utf-8")
   end
 end

--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -1,4 +1,5 @@
 Rails.application.config.active_storage.content_types_allowed_inline +=
   %w(
     text/plain
+    text/plain;\ charset=utf-8
   )


### PR DESCRIPTION
This sets the content type of uploaded text content (whether as code or as attachment) to include UTF-8 as charset, which ensures special characters are correctly rendered by browsers when later retrieving the content through the raw endpoint (matching the non-raw view).