### PR TITLE
Repair initial classification

### DIFF
--- a/app/controllers/pastes_controller.rb
+++ b/app/controllers/pastes_controller.rb
@@ -95,7 +95,13 @@ class PastesController < ApplicationController
     return unless text_content
 
     classifier = Rails.application.config.classifier
-    @marked_kind = classifier.classify(text_content).downcase
+
+    scores = classifier.classifications(text_content)
+    @marked_kind = if scores['Ham'].infinite? || scores['Spam'].infinite?
+                     'unclassified'
+                   else
+                     classifier.classify(text_content).downcase
+                   end
   end
 
   def text?

--- a/spec/requests/forbidden_terms_spec.rb
+++ b/spec/requests/forbidden_terms_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe 'Pastes with Forbidden Terms' do
         freeze_time do
           create_paste
           paste = Paste.last
-          expect(paste.marked_kind).to eq('ham')
+          expect(paste.marked_kind).to eq('unclassified')
           expect(paste.remove_at).to be > 5.seconds.from_now
         end
       end


### PR DESCRIPTION
If no training data existed yet, all pastes were marked as "Ham", but without being trained as "Ham". The "Unclassified" kind was not used at all (this was accidentally assumed to be expected behavior when adding the tests).

```
> classifier.classifications('fun')
=> {"Ham" => Infinity, "Spam" => Infinity}
> classifier.classify('fun')
=> "Ham"
```